### PR TITLE
envcmdsに指定したコマンドを実行すると空きメモリが減っていく挙動の修正

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -4680,7 +4680,7 @@ init_env:
 		movem.l	d1/a0-a1,-(a7)
 		movea.l	a0,a1
 		lea	env_top(a5),a0
-		bsr	xfreep
+		bsr	free_env_list
 		cmpa.l	#-1,a1
 		beq	init_env_done
 
@@ -4718,6 +4718,19 @@ init_env_return:
 init_env_no_memory:
 		moveq	#-1,d0
 		bra	init_env_return
+
+free_env_list:
+		move.l	(a0),d0
+		beq	9f
+		clr.l	(a0)
+		movea.l	d0,a0
+@@:
+		movea.l	var_next(a0),a0
+		bsr	free
+		move.l	a0,d0
+		bne	@b
+9:
+		rts
 ****************************************************************
 built_user_env:
 		movem.l	d1-d2/a0-a2,-(a7)

--- a/src/main.s
+++ b/src/main.s
@@ -117,6 +117,7 @@ PDB_stackPtr	equ	$f8
 .xref set_shellvar_nul
 .xref get_shellvar
 .xref get_var_value
+.xref freevar
 .xref dupvar
 .xref varsize
 .xref reset_cwd
@@ -4679,8 +4680,9 @@ check_executable_magic_error:
 init_env:
 		movem.l	d1/a0-a1,-(a7)
 		movea.l	a0,a1
-		lea	env_top(a5),a0
-		bsr	free_env_list
+		movea.l	env_top(a5),a0
+		bsr	freevar
+		clr.l	env_top(a5)
 		cmpa.l	#-1,a1
 		beq	init_env_done
 
@@ -4718,19 +4720,6 @@ init_env_return:
 init_env_no_memory:
 		moveq	#-1,d0
 		bra	init_env_return
-
-free_env_list:
-		move.l	(a0),d0
-		beq	9f
-		clr.l	(a0)
-		movea.l	d0,a0
-@@:
-		movea.l	var_next(a0),a0
-		bsr	free
-		move.l	a0,d0
-		bne	@b
-9:
-		rts
 ****************************************************************
 built_user_env:
 		movem.l	d1-d2/a0-a2,-(a7)


### PR DESCRIPTION
シェル変数`envcmds`に指定したコマンドを実行すると、実行後に環境変数リストの先頭の項目しかメモリ解放せず、それ以降の項目がメモリ解放されません。

コマンドの実行を繰り返すと、空きメモリが減っていきます。

再現方法
1. fishを起動します。
2. `set envcmds=COMMAND.X`
3. `COMMAND.X memfree`
4. 3を繰り返します。

環境変数の定義を増やすことで空きメモリが減る頻度が高まります。 
Human68k ver 3.02のシステムディスク(HUMAN302.XDF)に下記変更をすると
COMMAND.Xを3～4回起動するごとに減るようになります。

CONFIG.SYS
```
SHELL = A:\COMMAND.X /E:8
```
AUTOEXEC.BAT
```
ECHO OFF
PATH A:\;A:\SYS;A:\BIN;A:\BASIC2;A:\ETC;

set A0=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A1=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A2=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A3=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A4=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A5=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A6=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A7=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A8=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
set A9=0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
```

このパッチでは環境変数リストをたどって、先頭以外のメモリも解放するようにします。
